### PR TITLE
Add media query sorting, and add some Compiled limitations

### DIFF
--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -11,10 +11,9 @@ This page goes over what it is and what behaviors are enabled by using it.
 If you're just getting started don't feel the need to read this page,
 but if you're interested in understanding more under-the-hood keep on reading.
 
-## What is it
+## What is it?
 
-Atomic CSS is a method of reducing the total amount of defined rules by creating a single rule for every declaration —
-enabling large style re-use.
+Atomic CSS is a method of reducing the total amount of defined rules by creating a single rule (and in turn, a unique class name) for every declaration – enabling large style re-use.
 
 Take a regular looking style rule:
 
@@ -31,7 +30,7 @@ Take a regular looking style rule:
 <button className="button">Hello world</button>
 ```
 
-Transformed to atomic CSS every declaration is now a rule:
+If we apply the atomic CSS principle, every declaration is now its own rule:
 
 ```css
 .b-none {
@@ -55,8 +54,9 @@ Transformed to atomic CSS every declaration is now a rule:
 <button className="b-none fs-14 bgc-purple br-3">Hello world</button>
 ```
 
-When other components define the same styles they use the same rules.
-As your styles grow rules are created less often.
+(The actual class names that Compiled uses are different, but the principle is the same.)
+
+When other components define the same styles they use the same rules – creating no negative impact to the stylesheet size and less impact to the HTML size. As the size of your project increases, the stylesheet size grows less and less.
 
 ## Overriding through composition
 
@@ -159,40 +159,12 @@ We have [optimization ideas](https://github.com/atlassian-labs/compiled/issues/3
 
 ### Selector specificity
 
-Styles delivered with atomic CSS share the same [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity),
-so its up to their order in the style sheet to determine what takes presedence over the other.
-Compiled handles common [pseudo class ordering](#ordered-pseudos) for you,
-however other pseudo selectors including media queries may unexpectedly clash.
+Styles where several CSS blocks can be applied at once can be problematic (i.e. when using pseudo-selectors and at-rules). This is because styles delivered with atomic CSS share the same [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity),
+so it is up to their order in the stylesheet to determine what takes precedence over the other.  However, when importing CSS from Compiled components across several files or packages, the order in which CSS classes appear in the stylesheet may be non-deterministic.
 
-At those times an easy option could be to double the specificity using the [nesting selector](/writing-css#nesting-selector),
-however re-writing your styles so only a single declaration can take affect at once may prove more fruitful.
+Compiled sorts common [pseudo-class ordering](#ordered-pseudos) for you, as well as [all at-rules](/limitations#overlapping-styles) (including media queries) in *most* cases. However, other pseudo-selectors and situations may result in unpredictable behaviour.
 
-When adopting a mobile-first strategy, you might encounter something similar to the following.
-
-```jsx
-import { css } from "@compiled/react"
-
-const style = css({
-   "color": "yellow",
-   "@media (min-width: 720px)": { color: "red" },
-   "@media (min-width: 1280px)": { color: "green" }
-})
-```
-
-Both `@media (min-width: 30rem) { color: red }` and `@media (min-width: 64rem) { color: green }` can take affect at once.
-As mentioned above, it can cause unexpected behaviors.
-Instead, please make sure that only one declaration can take affect at once.
-
-```jsx
-import { css } from "@compiled/react"
-
-const style = css({
-   "color": "yellow",
-   "@media (min-width: 720px) and (max-width: 1279px)": { color: "red" },
-   "@media (min-width: 1280px)": { color: "green" }
-})
-```
-
+In cases where this is a problem, we recommend re-writing your styles so that only a single declaration can take effect at once. If this is not possible, you may resort to the [nesting selector](/writing-css#nesting-selector), however we do not recommend this.
 
 ## Other resources
 

--- a/packages/docs/src/pages/limitations.mdx
+++ b/packages/docs/src/pages/limitations.mdx
@@ -4,38 +4,190 @@ section: 50-Guides
 
 # Limitations
 
-The architecture of Compiled prevents some things that are possible with runtime libraries.
+The architecture or design of Compiled prevents some things that are possible with runtime libraries. There are also some features we would like to add to Compiled in the future that we have not yet.
 
 ## Runtime styles
 
 Styles can't be created at runtime which includes dynamic selectors as well.
 
 ```jsx
+/** @jsxImportSource @compiled/react */
+import { css } from '@compiled/react';
 const selectedIndex = useState(0);
 
-<div
-  css={{
-    // Will not work!
-    [`:nth-child(${selectedIndex})`]: {
-      display: 'block',
-    },
-  }}
-/>;
+const styles = css({
+  // Will not work!
+  [`:nth-child(${selectedIndex})`]: {
+    display: 'block',
+  },
+});
+
+<div css={styles}/>;
 ```
 
 If a dynamic value resolves to a static constant value however, it will work!
 
-## Missing behavior
+## Overlapping styles, caused by media queries and other at-rules
 
-Some behavior and features will be implemented in the future.
-Follow these issues to stay updated.
+Media queries and other at-rules are sorted deterministically when stylesheet extraction is turned on. See [this page](/media-queries-and-other-at-rules) for more details of how the sorting works and what its limitations are.
+
+## Unsupported features
+
+Below is a non-exhaustive list of features that Compiled does not support. Some are features we would like to add to Compiled at some point in the future, while others are features that we don't plan to implement.
+
+### Ternary operators
+
+There is a bug where ternary operators in the `css` prop won't work:
+
+```tsx
+/** @jsxImportSource @compiled/react */
+import { css } from '@compiled/react';
+
+const styles = css({ color: 'blue' });
+const otherStyles = css({ color: 'red' });
+
+// build-time error
+const Component = <div css={isPrimary ? styles : otherStyles}>Hello</div>
+```
+
+A workaround is to use the `&&` operator, which is supported:
+
+```tsx
+/** @jsxImportSource @compiled/react */
+import { css } from '@compiled/react';
+
+const styles = css({ color: 'blue' });
+const otherStyles = css({ color: 'red' });
+
+// build-time error
+const Component = <div css={[isPrimary && styles, !isPrimary && otherStyles]}>Hello</div>
+```
+
+There is a [bug report on GitHub](https://github.com/atlassian-labs/compiled/issues/389) if you would like to stay updated.
+
+### Theming
+
+We've elected not to support [`styled-components`-style theming](https://styled-components.com/docs/advanced#theming) in Compiled, as the implementation complexity is high, and the same effect can be achieved with CSS variables.
+
+See [here](https://github.com/atlassian-labs/compiled/issues/18) for the original (no longer pursued) GitHub proposal.
+
+### Component selectors
+
+We currently have no plans to support [component selectors](https://styled-components.com/docs/advanced#referring-to-other-components) in Compiled. This is due to Compiled's [atomic CSS](/atomic-css) design, where every style used is its own CSS class name. Component selectors would negate the benefits of atomic CSS in reducing stylesheet size.
+
+This can feel limiting in some situations, for example if you need styles to apply to a child component depending on a parent component's state (which is an issue that [other libraries face as well](https://github.com/facebook/stylex/issues/373)). Below is an example of this:
+
+```jsx
+import React from 'react';
+import styled from 'styled-components';
+
+const List = styled.div`
+  font-size: 2rem;
+`;
+
+const Item = styled.div`
+  color: green;
+
+  /* If List is hovered, then its children Items will turn red. */
+  ${List}:hover & {
+    color: red;
+  }
+`;
+
+function App() {
+  return (
+    <List>
+      <Item>Item 1</Item>
+      <Item>Item 2</Item>
+      <Item>Item 3</Item>
+    </List>
+  );
+}
+```
+
+While we don't currently have a first-class API to handle this use case, there are two potential approaches you can use to write this in Compiled.
+
+The recommended and more idiomatic way is to use JavaScript to pass state between the parent and child elements. There are many ways to achieve this – below is just one approach:
+
+```jsx
+/** @jsxImportSource @compiled/react */
+const { css } from '@compiled/react';
+
+const listStyles = css({ fontSize: '2rem' });
+const itemStyles = css({ color: 'green', });
+const redStyles = css({ color: 'red' });
+
+const List = ({ children, hoverCallback }) => (
+  <div
+    css={listStyles}
+    onMouseEnter={() => hoverCallback(true)}
+    onMouseLeave={() => hoverCallback(false)}
+  >
+    {children}
+  </div>
+);
+
+const Item = ({ children, isHover }) => (
+  <div css={[itemStyles, isHover && redStyles]}>
+    {children}
+  </div>
+);
+
+function App() {
+  const [isHover, setIsHover] = React.useState(false);
+  return (
+    <List hoverCallback={setIsHover}>
+      <Item isHover={isHover}>Item 1</Item>
+      <Item isHover={isHover}>Item 2</Item>
+      <Item isHover={isHover}>Item 3</Item>
+    </List>
+  );
+}
+```
+
+If the first method does not work for your use case, or if it degrades runtime performance to an unacceptable level, a workaround is to use a `data` attribute as a selector in your CSS. This is faster at runtime, but it negates the benefits of atomic CSS by bloating your stylesheet size (as mentioned earlier). In addition, the styles are much harder to statically analyse for any tooling from Compiled or the [Atlassian Design System](https://atlassian.design/):
+
+```jsx
+/** @jsxImportSource @compiled/react */
+const { css } from '@compiled/react';
+
+const listStyles = css({ fontSize: '2rem' });
+const itemStyles = css({
+  color: 'green',
+  '[data-component-selector="list-84d2"]:hover &': {
+    color: 'red',
+  },
+});
+
+const List = ({ children }) => (
+  <div data-component-selector="list-84d2" css={listStyles}>
+    {children}
+  </div>
+);
+
+const Item = ({ children }) => (
+  <div css={itemStyles}>
+    {children}
+  </div>
+);
+
+function App() {
+  return (
+    <List>
+      <Item>Item 1</Item>
+      <Item>Item 2</Item>
+      <Item>Item 3</Item>
+    </List>
+  );
+}
+```
+
+### Other unsupported features
 
 - [Conditional CSS rules for ClassNames](https://github.com/atlassian-labs/compiled/issues/391)
 - [Global component](https://github.com/atlassian-labs/compiled/issues/62)
-- [Theming](https://github.com/atlassian-labs/compiled/issues/18)
 
-## Bugs
+## Found a bug?
 
 When migrating over you may find some code that doesn't work as expected —
-in that case please [raise an issue](https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=&template=bug_report.md&title=Bug:&labels=bug%20%F0%9F%90%9B) and we'll look into it,
-bonus points if you put up a pull request as well!
+in that case please [raise an issue](https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=&template=bug_report.md&title=Bug:&labels=bug%20%F0%9F%90%9B) and we'll look into it. Bonus points if you put up a pull request as well!

--- a/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
+++ b/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
@@ -1,0 +1,135 @@
+---
+section: 50-Guides
+---
+
+
+# Media queries and other at-rules
+
+Media queries and other at-rules (e.g. `@layer` and `@supports`) are sorted based on a simplified version of the mobile-first sorting algorithm used by the [`sort-css-media-queries`](https://github.com/olehdutchenko/sort-css-media-queries/) library.
+
+A quick summary:
+
+* `min-width` and `min-height` are sorted from smallest to biggest, and then
+* `max-width` and `max-height` are sorted from biggest to smallest.
+* At-rules will be sorted alphabetically when they cannot be sorted another way.
+
+Note that this implies that `@layer` will be sorted as well, and as such, this is not compatible with `@layer`. You should not need to use `@layer` regardless, as Compiled's atomic CSS design removes the need to override specificity manually.
+
+Scroll down to the [full algorithm](#full-algorithm) for more details.
+
+## Limitations
+
+This sorting algorithm will be applied on a project-level basis when using a Compiled plugin in the bundler (`@compiled/webpack-loader` or `@compiled/parcel-config`) with stylesheet extraction turned on (`extract: true` in the Compiled configuration).
+
+This implies some caveats:
+
+* You'll need to turn on stylesheet extraction for this sorting to be guaranteed. If it is not turned on, at rules are not guaranteed to be sorted when there is more than one component.
+  * Without the de-duplication and sorting stage that occurs in our stylesheet extraction, each component's CSS will be concatenated together by the bundler without any additional processing. A media query from one component may be repeated later in the file for another component, and if they contain the same styles and thus use the same class names, we break our guarantees of a consistent ordering.
+* When using Parcel, you cannot use stylesheet extraction in development mode (e.g. `parcel serve`), and `extract: true` will have no effect. As a result, at-rule sorting will not apply. Parcel builds (`parcel build`) do not have this limitation.
+  * See the [bug report](https://github.com/atlassian-labs/compiled/issues/1306) on GitHub.
+* If you are importing Compiled components from another package, you will need either `@compiled/webpack-loader` or `@compiled/parcel-config` in your bundler settings for the sorting to work correctly.
+
+If either of the above situations apply to you, you should consider re-writing your at-rules (including media queries) in a way such that the ordering of the styles do not matter.
+
+For example, given this code:
+
+```jsx
+import { css } from '@compiled/react';
+
+const styles = css({
+   'color': 'yellow',
+   '@media (min-width: 720px)': { color: 'red' },
+   '@media (min-width: 1280px)': { color: 'green' },
+});
+```
+
+For any browser windows above `1280px` wide, any inconsistency in the ordering of the media queries will change the color from `red` to `green` (and vice versa).
+
+To avoid any potential ordering issues, we can change the code to this:
+
+```jsx
+import { css } from '@compiled/react';
+
+const styles = css({
+   'color': 'yellow',
+   '@media (min-width: 720px) and (width < 1280px)': { color: 'red' },
+   '@media (min-width: 1280px)': { color: 'green' },
+});
+```
+
+## Full algorithm
+
+Below is a description of the full sorting algorithm used by Compiled:
+
+1. The name of the at-rule, alphabetically (e.g. `@media`, `@supports`)
+2. `width > [number]` and `height > [number]`, from smallest to biggest
+3. `width >= [number]` and `min-width: [number]`, and `height >= [number]` and `min-height: [number]`, from smallest to biggest
+4. `width < [number]` and `height < [number]`, from biggest to smallest
+5. `width <= [number]` and `max-width: [number]`, and `height <= [number]` and `max-height: [number]`, from biggest to smallest
+6. `width = [number]` and `height = [number]`
+7. Repeat the previous steps (2 to 6), but for `device-width`, `device-height`, `min/max-device-width`, `min/max-device-height`
+8. If two at-rules are equal after applying the above sorting steps, at-rules with multiple features (e.g. `@media (width < 200px) and (height < 200px)`) will come after at-rules with fewer features (e.g. `@media (width < 200px)`).
+8. If there are no `width`/`height`/`device-width`/`device-height` features (or their `min`/`max` equivalents) in the at-rule, then the entire at-rule (e.g. `@media screen`) is sorted lexicographically (alphabetically) after at-rules that do contain these features.
+
+For example:
+
+```tsx
+const styles = css({
+  '@supports (display: grid)': {
+    display: 'grid',
+  },
+  '@media (300px <= height <= 400px)': {
+    color: 'green',
+  },
+  '@media (300px < height <= 400px)': {
+    color: 'red',
+  },
+  '@media (min-height: 300px)': {
+    color: 'yellow',
+  },
+  '@media (max-height: 300px)': {
+    color: 'purple',
+  },
+  '@media (min-height: 400px)': {
+    color: 'blue',
+  },
+  '@media (300px <= height)': {
+    color: 'orange',
+  },
+});
+```
+
+will be sorted at build-time to be equivalent to the following:
+
+```tsx
+const styles = css({
+  // parsed as @media (height > 300px) and (height <= 400px)
+  '@media (300px < height <= 400px)': {
+    color: 'red',
+  },
+  // parsed as @media (height >= 300px)
+  '@media (300px <= height)': {
+    color: 'orange',
+  },
+  // parsed as @media (height >= 300px)
+  '@media (min-height: 300px)': {
+    color: 'yellow',
+  },
+  // parsed as @media (height >= 300px) and (height <= 400px)
+  '@media (300px <= height <= 400px)': {
+    color: 'green',
+  },
+  // parsed as @media (height >= 400px)
+  '@media (min-height: 400px)': {
+    color: 'blue',
+  },
+  // parsed as @media (height <= 300px)
+  '@media (max-height: 300px)': {
+    color: 'purple',
+  },
+  '@supports (display: grid)': {
+    display: 'grid',
+  },
+});
+```
+

--- a/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
+++ b/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
@@ -42,7 +42,7 @@ Defaults to `false`.
 
 ### extractStylesToDirectory
 
-extractStylesToDirectory?: { source: string; dest: string };
+extractStylesToDirectory?: \{ source: string; dest: string \};
 
 When set, extracts styles to an external CSS file. This is beneficial for building platform components that are to be published on NPM.
 
@@ -74,7 +74,7 @@ Set the source folder and output folder relative to the root project path.
 ]
 ```
 
-It extracts the CSS sheet to a seperate file. 
+It extracts the CSS sheet to a seperate file.
 
 - dist
   - index.js
@@ -94,3 +94,11 @@ const Component = () =>
     'hello world'
   );
 ```
+
+### sortAtRules: boolean
+
+Whether to sort at-rules, including media queries.
+
+See [here](/media-queries-and-other-at-rules) for more information.
+
+Defaults to `true`.

--- a/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -138,13 +138,21 @@ See [enhanced-resolver docs](https://github.com/webpack/enhanced-resolve#resolve
 
 Defaults to none.
 
+### sortAtRules: boolean
+
+Whether to sort at-rules, including media queries.
+
+See [here](/media-queries-and-other-at-rules) for more information.
+
+Defaults to `true`.
+
 ### addComponentName: boolean
 
 Add the component name as class name to DOM in non-production environment if styled is used.
 
 Default to `false`
 
-### extractStylesToDirectory?: { source: string; dest: string };
+### extractStylesToDirectory?: \{ source: string; dest: string \};
 
 When set, extracts styles to an external CSS file. Read [babel-plugin-strip-runtime](/pkg-babel-plugin-strip-runtime#extractstylestodirectory) for more information.
 

--- a/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -173,7 +173,7 @@ module.exports = {
 };
 ```
 
-### extractStylesToDirectory?: { source: string; dest: string };
+### extractStylesToDirectory?: \{ source: string; dest: string \};
 
 When set, extracts styles to an external CSS file. Read [babel-plugin-strip-runtime](/pkg-babel-plugin-strip-runtime) for more information.
 

--- a/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -86,6 +86,14 @@ Add the component name as class name to DOM in non-production environment if sty
 
 Default to `false`
 
+### sortAtRules: boolean
+
+Whether to sort at-rules, including media queries.
+
+See [here](/media-queries-and-other-at-rules) for more information.
+
+Defaults to `true`.
+
 ### ssr: boolean
 
 To be used in conjunction with `extract: true` when having a different configuration for SSR.


### PR DESCRIPTION
Follow-up PR to https://github.com/atlassian-labs/compiled/pull/1666. Add details about the media query sorting and how it works.

While making this PR, I also noticed the Limitations page didn't have much detail, so I wrote up some Compiled limitations loosely based on some of the stuff we have in our internal docs. In a future PR, I plan to extend the Limitations page further, so that we no longer need our internal docs for almost all situations.