### PR TITLE
Update ESLint plugin website docs

### DIFF
--- a/packages/docs/src/pages/pkg-eslint-plugin.mdx
+++ b/packages/docs/src/pages/pkg-eslint-plugin.mdx
@@ -6,27 +6,26 @@ name: eslint-plugin
 
 # @compiled/eslint-plugin
 
-Accompanying [ESLint rules](https://eslint.org/docs/user-guide/configuring/configuration-files#using-a-configuration-from-a-plugin) useful when writing styles with Compiled.
+This plugin contains rules that should be used when working with `@compiled/react`.
 
-```bash
-npm install @compiled/eslint-plugin --save-dev
+## Usage
+
+For Atlassian-maintained projects, please install the [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/) instead of `@compiled/eslint-plugin`.
+
+The UI Styling Standard plugin is a superset of Compiled's ESLint rules that are customised to also apply to other CSS-in-JS libraries (Emotion, `styled-components`, and so on), not just Compiled. It also contains several additional rules that make your styling more statically analysable, reusable and composable, and more performant.
+
+For other projects, we recommend turning on all of the recommended rules for Compiled by adding `plugin:@compiled/recommended` in the `extends` section of your ESLint configuration:
+
+```diff
+// eslint.config.js
+
+export default [
+    {
++        "extends": ["plugin:@compiled/recommended"],
+        rules: {
+            semi: "error",
+            "prefer-const": "error"
+        }
+    }
+];
 ```
-
-```js
-module.exports = {
-  plugins: ['@compiled'],
-  rules: {
-    '@compiled/jsx-pragma': 'error',
-  },
-};
-```
-
-## Rules
-
-| Name                | Description                                           | Fixer | Recommended |
-| ------------------- | ----------------------------------------------------- | ----- | ----------- |
-| [no-emotion-css][1] | Use Compiled instead of Emotion                       | Yes   |             |
-| [jsx-pragma][2]     | Ensures a jsx pragma is set when using the `css` prop | Yes   | Yes         |
-
-[1]: https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-emotion-css
-[2]: https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/jsx-pragma

--- a/packages/docs/src/pages/pkg-eslint-plugin.mdx
+++ b/packages/docs/src/pages/pkg-eslint-plugin.mdx
@@ -29,3 +29,7 @@ export default [
     }
 ];
 ```
+
+## Rules
+
+See [here](https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin) for a list of rules in `@compiled/eslint-plugin`.

--- a/packages/docs/src/pages/pkg-eslint-plugin.mdx
+++ b/packages/docs/src/pages/pkg-eslint-plugin.mdx
@@ -12,7 +12,7 @@ This plugin contains rules that should be used when working with `@compiled/reac
 
 For Atlassian-maintained projects, please install the [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/) instead of `@compiled/eslint-plugin`.
 
-The UI Styling Standard plugin is a superset of Compiled's ESLint rules that are customised to also apply to other CSS-in-JS libraries (Emotion, `styled-components`, and so on), not just Compiled. It also contains several additional rules that make your styling more statically analysable, reusable and composable, and more performant.
+The UI Styling Standard plugin is a superset of Compiled's ESLint rules that are customised to also apply to other CSS-in-JS libraries (Emotion, `styled-components`, and so on), to make migration to Compiled easier. It also contains several additional rules that make your styling more statically analysable, reusable and composable, and more performant.
 
 For other projects, we recommend turning on all of the recommended rules for Compiled by adding `plugin:@compiled/recommended` in the `extends` section of your ESLint configuration:
 

--- a/packages/docs/src/pages/pkg-eslint-plugin.mdx
+++ b/packages/docs/src/pages/pkg-eslint-plugin.mdx
@@ -10,7 +10,7 @@ This plugin contains rules that should be used when working with `@compiled/reac
 
 ## Usage
 
-For Atlassian-maintained projects, please install the [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/) instead of `@compiled/eslint-plugin`.
+For projects in the Atlassian ecosystem or to adhere to Atlassian standards, please install the [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/) instead of `@compiled/eslint-plugin` (as it includes this plugin).
 
 The UI Styling Standard plugin is a superset of Compiled's ESLint rules that are customised to also apply to other CSS-in-JS libraries (Emotion, `styled-components`, and so on), to make migration to Compiled easier. It also contains several additional rules that make your styling more statically analysable, reusable and composable, and more performant.
 


### PR DESCRIPTION
Gave the `@compiled/eslint-plugin` docs an update.

* Add some info about the UI Styling Standard plugin that Atlassian frontend codebases should start using, as one person had discovered our Compiled ESLint plugin docs but were not able to find the UI Styling Standard docs
* Replace Rules section with a link to the Compiled repo, as it was pretty outdated already
* Generally have the page reflect what we recommend people do, without mentioning configurations we don't recommend